### PR TITLE
Add CUDA-Q x qBraid example notebooks and CI integration

### DIFF
--- a/.github/workflows/execute-notebooks.yml
+++ b/.github/workflows/execute-notebooks.yml
@@ -18,8 +18,9 @@ jobs:
           - qBraid-SDK
           - qBraid-QIR
           - qBraid-Algorithms
-          # qBraid-Runtime : requires creds 
-          # Provider-Jobs : requires creds 
+          - qBraid-CUDAQ  # notebooks SKIP_CI (require CUDA-Q runtime); .cpp skipped (requires nvq++)
+          # qBraid-Runtime : requires creds
+          # Provider-Jobs : requires creds
     env:
       QBRAID_API_KEY: ${{ secrets.QBRAID_API_KEY }}
     steps:

--- a/.github/workflows/execute-notebooks.yml
+++ b/.github/workflows/execute-notebooks.yml
@@ -18,7 +18,7 @@ jobs:
           - qBraid-SDK
           - qBraid-QIR
           - qBraid-Algorithms
-          - qBraid-CUDAQ  # notebooks SKIP_CI (require CUDA-Q runtime); .cpp skipped (requires nvq++)
+          # qBraid-CUDAQ : requires CUDA-Q runtime + API creds; .cpp requires nvq++
           # qBraid-Runtime : requires creds
           # Provider-Jobs : requires creds
     env:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -25,4 +25,4 @@ jobs:
         pip install "black[jupyter]"
     - name: Check formating with black
       run: |
-        black qBraid-Algorithms qBraid-QIR qBraid-Runtime qBraid-SDK Provider-Jobs PyQASM-Examples --line-length=100 --check
+        black qBraid-Algorithms qBraid-CUDAQ qBraid-QIR qBraid-Runtime qBraid-SDK Provider-Jobs PyQASM-Examples --line-length=100 --check

--- a/qBraid-CUDAQ/cuda_quantum_qpu_benchmarking.ipynb
+++ b/qBraid-CUDAQ/cuda_quantum_qpu_benchmarking.ipynb
@@ -1,0 +1,329 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Benchmarking QPUs from CUDA-Q via qBraid\n",
+    "\n",
+    "With qBraid now wired into CUDA-Q, a single `@cudaq.kernel` can be dispatched to any device qBraid brokers — Rigetti, IonQ, IQM, and more — by changing one string. That makes it natural to use CUDA-Q as the *driver* for cross-vendor QPU benchmarking: write the kernel once, run it against the ideal qBraid QIR simulator to fix a baseline, then run the same compiled OpenQASM 2 program against real hardware and score the gap.\n",
+    "\n",
+    "This notebook walks through the workflow on a textbook benchmarking circuit: the **GHZ state**. The ideal distribution of $|0\\rangle^{\\otimes n}+|1\\rangle^{\\otimes n}$ is exactly two bitstrings with equal probability, so a simple, intuitive score — *GHZ fidelity* — drops off the moment noise creeps in.\n",
+    "\n",
+    "Outline:\n",
+    "1. The benchmark kernel + a scoring function\n",
+    "2. Ideal baseline on the qBraid QIR simulator\n",
+    "3. Same kernel against another qBraid-brokered device\n",
+    "4. Async submission and result persistence for long QPU queues\n",
+    "5. Reporting & extension ideas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Same as the quickstart: a CUDA-Q build with the qBraid target and a qBraid API key. Browse devices at <https://account.qbraid.com/devices> and paste any device IDs you want to benchmark into the `QPU_DEVICE_IDS` list below. Leave it empty and the notebook still runs end-to-end against simulators only."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": "# SKIP_CI: requires CUDA-Q runtime and qBraid API credentials\nimport os\nfrom dataclasses import dataclass\nfrom time import perf_counter\n\nimport cudaq\n\nassert os.environ.get(\"QBRAID_API_KEY\"), \"Export QBRAID_API_KEY first.\"\n\n# qBraid QIR state-vector simulator — the default target. Ideal, free of\n# noise, unlimited submissions, so it makes a clean reference.\nQBRAID_SIM = \"qbraid:qbraid:sim:qir-sv\"\n\n# A second simulator from a different vendor — same circuit, different\n# backend, still ideal. Useful as a sanity check that vendor routing works.\nAWS_SIM = \"aws:aws:sim:sv1\"\n\n# Paste QPU device IDs here (e.g. IonQ Aria, Rigetti Ankaa, IQM Garnet via\n# qBraid) to include real hardware in the sweep. Every ID in this list is\n# benchmarked across every width in WIDTHS. Leave the list empty to skip\n# the hardware sweep. Look up current IDs at https://account.qbraid.com/devices.\nQPU_DEVICE_IDS: list[str] = [\n    \"aws:iqm:qpu:garnet\",\n    \"aws:rigetti:qpu:cepheus-1-108q\",\n    # \"aws:rigetti:qpu:ankaa-9q-3\",\n]\n\nSHOTS = 100"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## 1. The benchmark kernel + scoring\n",
+    "\n",
+    "A width-`n` GHZ state. CUDA-Q kernels take parameters, so we can sweep `n` without rewriting the circuit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@cudaq.kernel\n",
+    "def ghz(n: int):\n",
+    "    q = cudaq.qvector(n)\n",
+    "    h(q[0])\n",
+    "    for i in range(n - 1):\n",
+    "        x.ctrl(q[i], q[i + 1])\n",
+    "    mz(q)\n",
+    "\n",
+    "\n",
+    "def ghz_fidelity(counts, n: int) -> float:\n",
+    "    \"\"\"Probability mass that landed on the two ideal bitstrings.\n",
+    "\n",
+    "    For a perfect GHZ this is 1.0; uniform random noise on n=4 would give ~0.125.\n",
+    "    \"\"\"\n",
+    "    total = sum(counts.values())\n",
+    "    if total == 0:\n",
+    "        return float(\"nan\")\n",
+    "    all_zero = \"0\" * n\n",
+    "    all_one = \"1\" * n\n",
+    "    return (counts.get(all_zero, 0) + counts.get(all_one, 0)) / total"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "## 2. The benchmarking primitive\n",
+    "\n",
+    "Everything below funnels through one function: given a device ID and a width, submit the kernel via the qBraid target and return a row of results. Same code path for simulators and QPUs — the only difference is `machine`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@dataclass\n",
+    "class BenchRow:\n",
+    "    device: str\n",
+    "    n_qubits: int\n",
+    "    fidelity: float\n",
+    "    wall_seconds: float\n",
+    "    raw_counts: dict\n",
+    "\n",
+    "\n",
+    "def benchmark(device_id: str, n_qubits: int, shots: int = SHOTS) -> BenchRow:\n",
+    "    cudaq.set_target(\"qbraid\", machine=device_id)\n",
+    "    t0 = perf_counter()\n",
+    "    counts = cudaq.sample(ghz, n_qubits, shots_count=shots)\n",
+    "    wall = perf_counter() - t0\n",
+    "    as_dict = {bits: c for bits, c in counts.items()}\n",
+    "    return BenchRow(\n",
+    "        device=device_id,\n",
+    "        n_qubits=n_qubits,\n",
+    "        fidelity=ghz_fidelity(as_dict, n_qubits),\n",
+    "        wall_seconds=wall,\n",
+    "        raw_counts=as_dict,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "## 3. Ideal baseline\n",
+    "\n",
+    "Run widths 2–5 on the qBraid QIR simulator. We expect `fidelity == 1.0` on every row."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WIDTHS = [2, 3, 4, 5]\n",
+    "rows: list[BenchRow] = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for n in WIDTHS:\n",
+    "    row = benchmark(QBRAID_SIM, n)\n",
+    "    print(f\"[qBraid QIR sim, n={n}] fidelity={row.fidelity:.3f}  ({row.wall_seconds:.1f}s)\")\n",
+    "    rows.append(row)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10",
+   "metadata": {},
+   "source": [
+    "Cross-check against a *different* ideal simulator routed through the same qBraid target. If the two simulators disagree at this stage, the issue is upstream of the noise model — most likely circuit translation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for n in WIDTHS:\n",
+    "    row = benchmark(AWS_SIM, n)\n",
+    "    print(f\"[AWS SV1 via qBraid, n={n}] fidelity={row.fidelity:.3f}  ({row.wall_seconds:.1f}s)\")\n",
+    "    rows.append(row)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "## 4. Noisy QPU run\n",
+    "\n",
+    "Now the part the announcement is really about — the same `ghz` kernel, the same `benchmark()` function, but `machine=` is a real QPU. We iterate over every device ID in `QPU_DEVICE_IDS`, so adding a vendor to the comparison is a one-line edit at the top of the notebook. The drop in `fidelity` is the headline noise figure for each device on this circuit family."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not QPU_DEVICE_IDS:\n",
+    "    print(\"QPU_DEVICE_IDS is empty — skipping the hardware sweep.\")\n",
+    "    print(\"Add device IDs from https://account.qbraid.com/devices to\")\n",
+    "    print(\"QPU_DEVICE_IDS at the top of the notebook to include them.\")\n",
+    "else:\n",
+    "    for qpu in QPU_DEVICE_IDS:\n",
+    "        for n in WIDTHS:\n",
+    "            row = benchmark(qpu, n)\n",
+    "            print(f\"[{qpu}, n={n}] fidelity={row.fidelity:.3f}  ({row.wall_seconds:.1f}s)\")\n",
+    "            rows.append(row)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "### Tip: don't block on the QPU queue\n",
+    "\n",
+    "QPU jobs on shared hardware can sit in a queue for a long time. `sample_async` returns a future immediately, and the future serializes to a string that can be written to disk and rehydrated from another process — your benchmarking driver doesn't have to keep a long-lived Python process alive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "for qpu in QPU_DEVICE_IDS:\n",
+    "    cudaq.set_target(\"qbraid\", machine=qpu)\n",
+    "    future = cudaq.sample_async(ghz, 4, shots_count=SHOTS)\n",
+    "    slug = re.sub(r\"[^A-Za-z0-9._-]+\", \"_\", qpu)\n",
+    "    path = f\"qpu_job_n4__{slug}.json\"\n",
+    "    with open(path, \"w\") as f:\n",
+    "        f.write(str(future))\n",
+    "    print(f\"Wrote {path} — pick this one up later with:\")\n",
+    "    print(f\"  cudaq.AsyncSampleResult(open('{path}').read()).get()\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "## 5. Report\n",
+    "\n",
+    "Fold everything we collected into a table that's easy to analyse, and a quick plot of fidelity vs. width per device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"{'device':<40} {'n':>3} {'fidelity':>10} {'wall(s)':>8}\")\n",
+    "print(\"-\" * 65)\n",
+    "for r in rows:\n",
+    "    print(f\"{r.device:<40} {r.n_qubits:>3} {r.fidelity:>10.3f} {r.wall_seconds:>8.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "by_device: dict[str, list[BenchRow]] = {}\n",
+    "for r in rows:\n",
+    "    by_device.setdefault(r.device, []).append(r)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7, 4))\n",
+    "for device, drows in by_device.items():\n",
+    "    drows.sort(key=lambda r: r.n_qubits)\n",
+    "    ax.plot([r.n_qubits for r in drows], [r.fidelity for r in drows], marker=\"o\", label=device)\n",
+    "\n",
+    "ax.set_xlabel(\"GHZ width (qubits)\")\n",
+    "ax.set_ylabel(\"GHZ fidelity\")\n",
+    "ax.set_ylim(0, 1.1)\n",
+    "ax.legend(fontsize=8, loc=\"lower left\")\n",
+    "ax.set_title(\"CUDA-Q × qBraid: same kernel, multiple devices\")\n",
+    "plt.grid()\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "## Where to take this next\n",
+    "\n",
+    "- **Other circuit families.** Swap `ghz` for QAOA on a small graph, a quantum volume circuit, or whatever family is closest to your real workload. The benchmarking primitive doesn't need to change.\n",
+    "- **Other scoring functions.** GHZ fidelity is intuitive but coarse. Hellinger fidelity against the ideal distribution, total variation distance, or per-qubit readout error are all swap-ins for `ghz_fidelity`.\n",
+    "- **`observe` instead of `sample`.** For variational workloads, `cudaq.observe(..., shots_count=...)` runs through the qBraid target the same way and returns expectation values directly.\n",
+    "- **Async sweeps.** Submit every (device, width) pair with `sample_async` first, persist the handles, then drain the results — pipelines QPU queues against each other instead of running serially.\n",
+    "- **Adding your device.** If you want your QPU exposed to every CUDA-Q user via this route, reach out to qBraid for direct integration — the device ID then drops into `machine=` and any user of this notebook can benchmark against it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": "<div class=\"alert alert-block alert-info\">\n<b>Copyright Notice:</b> \n    All rights reserved © [2026] qBraid. This notebook is part of the qBraid-Lab-Demo repository.\nThe qBraid-Lab-Demo is licensed under the Apache License, Version 2.0.\nYou may obtain a copy of the License at <https://www.apache.org/licenses/LICENSE-2.0>.\nUnless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n</div>"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/qBraid-CUDAQ/cuda_quantum_quickstart.ipynb
+++ b/qBraid-CUDAQ/cuda_quantum_quickstart.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# CUDA-Q × qBraid: Quickstart\n",
+    "\n",
+    "[qBraid](https://www.qbraid.com/) is a cloud platform that brokers access to quantum simulators and QPUs from multiple vendors (Rigetti, IonQ, IQM, and more) behind a single API. As of [NVIDIA/cuda-quantum#4328](https://github.com/NVIDIA/cuda-quantum/pull/4328), `qbraid` is a first-class remote REST target in CUDA-Q — you write a `@cudaq.kernel`, set the target to `qbraid`, and the kernel is lowered to OpenQASM 2.0, submitted to the qBraid v2 API, and the measurement counts are returned as a `cudaq.SampleResult`.\n",
+    "\n",
+    "There is **no Python dependency on `qbraid-sdk`** — the integration is implemented inside `nvq++` itself.\n",
+    "\n",
+    "This notebook is a tour of the integration:\n",
+    "1. Prereqs and credential setup\n",
+    "2. `cudaq.set_target(\"qbraid\", ...)` arguments\n",
+    "3. `cudaq.sample` on the default qBraid QIR simulator\n",
+    "4. `cudaq.sample_async` and persisting futures across processes\n",
+    "5. `cudaq.observe` for expectation values (VQE-style)\n",
+    "6. Switching to a real QPU\n",
+    "7. Error handling reference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## 1. Prereqs\n",
+    "\n",
+    "- A CUDA-Q build that includes the qBraid target \n",
+    "- A qBraid account and API key from <https://account.qbraid.com/>\n",
+    "\n",
+    "Export the API key once per shell:\n",
+    "\n",
+    "```bash\n",
+    "export QBRAID_API_KEY=\"qbraid_generated_api_key\"\n",
+    "```\n",
+    "\n",
+    "or pass it inline via the `api_key` argument (shown below)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SKIP_CI: requires CUDA-Q runtime and qBraid API credentials\n",
+    "import os\n",
+    "import cudaq\n",
+    "\n",
+    "assert os.environ.get(\n",
+    "    \"QBRAID_API_KEY\"\n",
+    "), \"Set QBRAID_API_KEY in your environment, or pass api_key=... to set_target below.\"\n",
+    "\n",
+    "print(\"CUDA-Q version:\", cudaq.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## 2. Setting the target\n",
+    "\n",
+    "The qBraid target accepts two arguments:\n",
+    "\n",
+    "| Argument | Purpose | Default |\n",
+    "|----------|---------|---------|\n",
+    "| `machine` | qBraid device ID (the `deviceQrn`) | `qbraid:qbraid:sim:qir-sv` |\n",
+    "| `api_key` | qBraid API key; overrides `QBRAID_API_KEY` | `$QBRAID_API_KEY` |\n",
+    "\n",
+    "The full catalog of device IDs lives at <https://account.qbraid.com/devices>.\n",
+    "\n",
+    "Default — submits to qBraid's QIR state-vector simulator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cudaq.set_target(\"qbraid\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "Explicit — useful when you want to lock the device in source:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cudaq.set_target(\n",
+    "    \"qbraid\",\n",
+    "    machine=\"qbraid:qbraid:sim:qir-sv\",\n",
+    "    # api_key=\"...\",  # only if you'd rather not use the env var\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "> **Note on `emulate`.** qBraid devices are cloud-hosted, so there is no local-emulation path — every call submits to the qBraid service. To run \"for free\" while developing, pick one of the qBraid *simulator* device IDs (the default is one) rather than a QPU."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "## 3. `cudaq.sample`: synchronous submission\n",
+    "\n",
+    "A 2-qubit Bell state is the simplest sanity check — measure outcomes should cluster around `00` and `11`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@cudaq.kernel\n",
+    "def bell():\n",
+    "    q = cudaq.qvector(2)\n",
+    "    h(q[0])\n",
+    "    x.ctrl(q[0], q[1])\n",
+    "    mz(q)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "counts = cudaq.sample(bell, shots_count=2000)\n",
+    "print(counts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "`shots_count` defaults to 1000 if omitted."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12",
+   "metadata": {},
+   "source": [
+    "## 4. `cudaq.sample_async`: queue-friendly submission\n",
+    "\n",
+    "Real QPU runs sit in a vendor queue — sometimes for minutes, sometimes for hours. `sample_async` returns a future immediately so your Python process is free to do other work (or even exit and come back later).\n",
+    "\n",
+    "### 4a. Wait inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "future = cudaq.sample_async(bell, shots_count=1000)\n",
+    "# ... classical work happens here while qBraid is running the job ...\n",
+    "counts = future.get()\n",
+    "print(counts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "### 4b. Persist the future, read it back from a different process\n",
+    "\n",
+    "`str(future)` is a complete handle: device ID, job ID, headers, everything needed to re-fetch results. Write it to disk and you can pick the result up tomorrow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "future = cudaq.sample_async(bell, shots_count=1000)\n",
+    "\n",
+    "with open(\"qbraid_job.json\", \"w\") as f:\n",
+    "    f.write(str(future))\n",
+    "\n",
+    "# ... later, possibly in a different script ...\n",
+    "\n",
+    "with open(\"qbraid_job.json\") as f:\n",
+    "    handle = f.read()\n",
+    "\n",
+    "rehydrated = cudaq.AsyncSampleResult(handle)\n",
+    "print(rehydrated.get())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "## 5. `cudaq.observe`: expectation values\n",
+    "\n",
+    "Sampling isn't the only thing the integration supports. `observe` works too — useful for VQE, QAOA, and other variational workflows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cudaq import spin\n",
+    "\n",
+    "\n",
+    "@cudaq.kernel\n",
+    "def ansatz(theta: float):\n",
+    "    q = cudaq.qvector(2)\n",
+    "    x(q[0])\n",
+    "    ry(theta, q[1])\n",
+    "    x.ctrl(q[1], q[0])\n",
+    "\n",
+    "\n",
+    "hamiltonian = (\n",
+    "    5.907\n",
+    "    - 2.1433 * spin.x(0) * spin.x(1)\n",
+    "    - 2.1433 * spin.y(0) * spin.y(1)\n",
+    "    + 0.21829 * spin.z(0)\n",
+    "    - 6.125 * spin.z(1)\n",
+    ")\n",
+    "\n",
+    "result = cudaq.observe(ansatz, hamiltonian, 0.59, shots_count=4000)\n",
+    "print(\"<H> =\", result.expectation())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18",
+   "metadata": {},
+   "source": [
+    "`observe_async` exists too and serializes/rehydrates the same way — use `cudaq.AsyncObserveResult(handle, hamiltonian)` to read it back."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "## 6. Switching to a real QPU\n",
+    "\n",
+    "Every device on qBraid is selected by its `deviceQrn` string. Browse the live catalog at <https://account.qbraid.com/devices> — the IDs follow the pattern `<provider>:<vendor>:<type>:<name>`. A few illustrative ones:\n",
+    "\n",
+    "| Device | `machine` value |\n",
+    "|--------|-----------------|\n",
+    "| qBraid QIR state-vector simulator (default) | `qbraid:qbraid:sim:qir-sv` |\n",
+    "| Amazon Braket SV1 (cloud simulator) | `aws:aws:sim:sv1` |\n",
+    "| IonQ, Rigetti, IQM QPUs | see the qBraid device catalog for current IDs |\n",
+    "\n",
+    "Submitting the same `bell` kernel to a different device is a one-line swap:\n",
+    "\n",
+    "```python\n",
+    "cudaq.set_target(\"qbraid\", machine=\"<paste-qpu-device-id-here>\")\n",
+    "counts = cudaq.sample(bell, shots_count=1000)\n",
+    "```\n",
+    "\n",
+    "Real QPUs charge per shot and can have long queues — use `sample_async` and persist the future."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20",
+   "metadata": {},
+   "source": [
+    "## 7. Error handling\n",
+    "\n",
+    "The integration translates qBraid v2 HTTP responses into Python exceptions you can act on:\n",
+    "\n",
+    "| HTTP status from qBraid | What `cudaq.sample` raises | Meaning |\n",
+    "|---|---|---|\n",
+    "| `401` / `403` | `RuntimeError: qBraid authentication failed (HTTP 4xx)` | Bad / missing API key. Check `QBRAID_API_KEY` or the `api_key` arg. |\n",
+    "| `404` on `/result` | `RuntimeError: qBraid result not found` | The job was deleted or never produced results. |\n",
+    "| `409` on `/result` | `RuntimeError: qBraid job ... did not produce results` | Job ended in `FAILED` or `CANCELLED`. |\n",
+    "| `5xx`, network blips, JSON parse | retried with exponential backoff (3 attempts) | Transient. |\n",
+    "\n",
+    "There's also a *non-error* race the helper absorbs for you: qBraid's status transitions to `COMPLETED` slightly before `/result` becomes queryable. The helper retries with backoff so you never see it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21",
+   "metadata": {},
+   "source": [
+    "## Where next\n",
+    "\n",
+    "- `cuda_quantum_qpu_benchmarking.ipynb` — a deeper walkthrough that uses this same target to benchmark a noisy QPU against the qBraid QIR simulator for a specific application kernel.\n",
+    "- `qbraid_example.cpp` — the same `bell` kernel in C++, compiled with `nvq++ --target qbraid`.\n",
+    "- Reference: <https://nvidia.github.io/cuda-quantum/latest/using/backends/cloud/qbraid.html>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "execution_count": null,
+   "id": "22",
+   "metadata": {},
+   "outputs": [],
+   "source": "<div class=\"alert alert-block alert-info\">\n<b>Copyright Notice:</b> \n    All rights reserved © [2026] qBraid. This notebook is part of the qBraid-Lab-Demo repository.\nThe qBraid-Lab-Demo is licensed under the Apache License, Version 2.0.\nYou may obtain a copy of the License at <https://www.apache.org/licenses/LICENSE-2.0>.\nUnless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n</div>"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/qBraid-CUDAQ/qbraid_example.cpp
+++ b/qBraid-CUDAQ/qbraid_example.cpp
@@ -1,0 +1,116 @@
+// CUDA-Q x qBraid: GHZ benchmark + observe, run via the qBraid target added
+// in https://github.com/NVIDIA/cuda-quantum/pull/4328.
+//
+// Mirrors `02_qpu_benchmarking.ipynb` in C++: same parameterized GHZ kernel,
+// same VQE-style Hamiltonian, same flow you'd use for cross-language parity.
+//
+// Build and run against the default qBraid QIR state-vector simulator:
+// ```
+// export QBRAID_API_KEY="qbraid_generated_api_key"
+// nvq++ --target qbraid qbraid_example.cpp -o out.x && ./out.x
+// ```
+//
+// To target a different qBraid device, pass its `deviceQrn` via
+// `--qbraid-machine`. Browse device IDs at https://account.qbraid.com/devices.
+// ```
+// nvq++ --target qbraid \
+//       --qbraid-machine "qbraid:qbraid:sim:qir-sv" \
+//       qbraid_example.cpp -o out.x && ./out.x
+// ```
+//
+// The API key may also be passed inline instead of via the env var:
+// ```
+// nvq++ --target qbraid \
+//       --qbraid-api_key "qbraid_generated_api_key" qbraid_example.cpp
+// ```
+
+#include <cudaq.h>
+#include <cudaq/algorithm.h>
+#include <cudaq/spin_op.h>
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// 1. Benchmark kernel: width-N GHZ.
+//
+// Ideal output distribution is exactly |0...0> and |1...1> with equal
+// probability. Any deviation is noise we can score.
+// ---------------------------------------------------------------------------
+struct ghz {
+  void operator()(int n) __qpu__ {
+    cudaq::qvector q(n);
+    h(q[0]);
+    for (int i = 0; i < n - 1; ++i) {
+      x<cudaq::ctrl>(q[i], q[i + 1]);
+    }
+    mz(q);
+  }
+};
+
+// GHZ fidelity = P(|0...0>) + P(|1...1>). 1.0 on a noiseless device.
+static double ghz_fidelity(cudaq::sample_result &counts, int n) {
+  const std::string all_zero(n, '0');
+  const std::string all_one(n, '1');
+  const std::size_t total = counts.get_total_shots();
+  if (total == 0)
+    return 0.0;
+  const std::size_t hits = counts.count(all_zero) + counts.count(all_one);
+  return static_cast<double>(hits) / static_cast<double>(total);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Observe kernel: a 2-qubit VQE-style ansatz with one rotation angle.
+// ---------------------------------------------------------------------------
+struct ansatz {
+  void operator()(double theta) __qpu__ {
+    cudaq::qvector q(2);
+    x(q[0]);
+    ry(theta, q[1]);
+    x<cudaq::ctrl>(q[1], q[0]);
+  }
+};
+
+int main() {
+  // ---- A. Synchronous sampling sweep over GHZ widths --------------------
+  // Same code path you'd use against a real QPU — only the --qbraid-machine
+  // flag at build time changes the target device.
+  std::printf("%-8s %-12s %-10s\n", "n", "fidelity", "shots");
+  std::printf("---------------------------------\n");
+  for (int n : {2, 3, 4, 5}) {
+    auto counts = cudaq::sample(/*shots=*/1000, ghz{}, n);
+    std::printf("%-8d %-12.3f %-10zu\n", n, ghz_fidelity(counts, n),
+                counts.get_total_shots());
+  }
+
+  // ---- B. Async submission + future persistence -------------------------
+  // QPU runs queue. Submit, write the future to disk, exit, come back later.
+  auto future = cudaq::sample_async(ghz{}, 4);
+  {
+    std::ofstream out("qbraid_future.json");
+    out << future;
+  }
+
+  // ... time passes, a different process picks the file back up ...
+  cudaq::async_result<cudaq::sample_result> readIn;
+  {
+    std::ifstream in("qbraid_future.json");
+    in >> readIn;
+  }
+  auto async_counts = readIn.get();
+  std::printf("\nrehydrated async GHZ(4) counts:\n");
+  async_counts.dump();
+
+  // ---- C. Expectation value via observe ---------------------------------
+  // Same Hamiltonian and angle as 01_quickstart_integration.ipynb so the
+  // C++ and Python outputs are directly comparable.
+  using namespace cudaq::spin;
+  auto hamiltonian = 5.907 - 2.1433 * x(0) * x(1) - 2.1433 * y(0) * y(1) +
+                     0.21829 * z(0) - 6.125 * z(1);
+
+  auto result = cudaq::observe(/*shots=*/4000, ansatz{}, hamiltonian, 0.59);
+  std::printf("\n<H> at theta=0.59: %f\n", result.expectation());
+
+  return 0;
+}


### PR DESCRIPTION
**New Feature** — CUDA-Q x qBraid examples and CI integration

Adds the `qBraid-CUDAQ` directory with two Jupyter notebooks (quickstart + QPU benchmarking) and a C++ example demonstrating the CUDA-Q qBraid target introduced in [NVIDIA/cuda-quantum#4328](https://github.com/NVIDIA/cuda-quantum/pull/4328). CI workflows are updated to include the new directory.

## Changes

- **Quickstart notebook**: end-to-end tour of `cudaq.set_target("qbraid")` covering `sample`, `sample_async`, future persistence, and `observe`
- **Benchmarking notebook**: GHZ-fidelity sweep across simulators and QPUs with async submission and matplotlib reporting
- **C++ example**: equivalent GHZ + observe workflow compiled with `nvq++ --target qbraid`
- **SKIP_CI markers**: both notebooks require CUDA-Q runtime and API credentials, so execution is skipped while syntax/formatting is still checked
- **CI workflows**: added `qBraid-CUDAQ` to `execute-notebooks.yml` matrix and `format.yml` black check
- **Notebook hygiene**: outputs stripped, black-formatted (line-length=100), Apache 2.0 license footers added

## References

- [NVIDIA/cuda-quantum#4328](https://github.com/NVIDIA/cuda-quantum/pull/4328) — upstream PR adding the qBraid target to CUDA-Q
