### PR TITLE
Fix Execute Notebooks CI for fork PRs

### DIFF
--- a/.github/workflows/check-notebook-license.yml
+++ b/.github/workflows/check-notebook-license.yml
@@ -2,7 +2,7 @@ name: Check Notebook License Footers
 
 on:
   pull_request:
-    branches: ['main']
+    branches: ['main', 'staging']
     types: [opened, reopened, ready_for_review, synchronize]
   workflow_dispatch:
 

--- a/.github/workflows/check-notebook-outputs.yml
+++ b/.github/workflows/check-notebook-outputs.yml
@@ -2,7 +2,7 @@ name: Check Notebook Outputs
 
 on:
   pull_request:
-    branches: ['main']
+    branches: ['main', 'staging']
     types: [opened, reopened, ready_for_review, synchronize]
   workflow_dispatch:
 

--- a/.github/workflows/execute-notebooks.yml
+++ b/.github/workflows/execute-notebooks.yml
@@ -70,6 +70,14 @@ jobs:
             continue
           fi
 
+          # Skip notebooks that authenticate with the qBraid API when no key is
+          # available (secrets are not exposed to pull_request runs from forks)
+          if [ -z "$QBRAID_API_KEY" ] && grep -qE "QbraidProvider|QbraidClient" "$nb"; then
+            summary="${summary}| ${name} | :white_circle: SKIPPED (no API key on fork PRs) |\n"
+            skipped=$((skipped + 1))
+            continue
+          fi
+
           echo "::group::Executing $nb"
           if .venv/bin/jupyter nbconvert --to notebook --execute \
             --ExecutePreprocessor.kernel_name=notebook-env \

--- a/.github/workflows/execute-notebooks.yml
+++ b/.github/workflows/execute-notebooks.yml
@@ -2,7 +2,7 @@ name: Execute Notebooks
 
 on:
   pull_request:
-    branches: ['main']
+    branches: ['main', 'staging']
     types: [opened, reopened, ready_for_review, synchronize]
   workflow_dispatch:
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,7 +2,7 @@ name: Format
 
 on:
   pull_request:
-    branches: ['main']
+    branches: ['main', 'staging']
     types: [opened, reopened, ready_for_review, synchronize]
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary

Fork PRs (e.g. #65) fail the **Execute Notebooks** checks with `401 Unauthorized` because GitHub does not expose repository secrets to `pull_request` workflow runs triggered from forks — `QBRAID_API_KEY` arrives empty regardless of the repo secret configuration.

This adds a skip rule: when `QBRAID_API_KEY` is empty, notebooks that authenticate with the qBraid API (`QbraidProvider` / `QbraidClient`) are skipped and reported as `SKIPPED (no API key on fork PRs)` in the job summary. PRs from branches in this repo still execute them fully since the secret is available there.

Once merged, re-running the failed checks on #65 will pick up the updated workflow (pull_request runs use the merge commit's workflow file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)